### PR TITLE
Add authentication context and login service

### DIFF
--- a/instagrao/src/App.js
+++ b/instagrao/src/App.js
@@ -3,17 +3,20 @@ import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 
 import LoginForm from './paginas/Login';
 import PaginaInicial from './paginas/PaginaInicial';
+import { AuthProvider } from './context/AuthContext';
 import './App.css';
 
 const App = () => {
   return (
     <Router>
-      <div className="App">
-        <Routes>
-          <Route path="/" element={<LoginForm />} />
-          <Route path="/pagina-inicial" element={<PaginaInicial />} />
-        </Routes>
-      </div>
+      <AuthProvider>
+        <div className="App">
+          <Routes>
+            <Route path="/" element={<LoginForm />} />
+            <Route path="/pagina-inicial" element={<PaginaInicial />} />
+          </Routes>
+        </div>
+      </AuthProvider>
     </Router>
   );
 

--- a/instagrao/src/App.test.js
+++ b/instagrao/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders login form', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByText(/Instagrão/i);
+  expect(heading).toBeInTheDocument();
 });

--- a/instagrao/src/context/AuthContext.js
+++ b/instagrao/src/context/AuthContext.js
@@ -1,0 +1,50 @@
+import React, { createContext, useState, useEffect } from 'react';
+import {
+  getCurrentUser,
+  loginUser,
+  registerUser,
+  logoutUser,
+} from '../services/authService';
+
+const AuthContext = createContext();
+
+export const AuthProvider = ({ children }) => {
+  const [user, setUser] = useState(null);
+
+  useEffect(() => {
+    const stored = getCurrentUser();
+    if (stored) {
+      setUser(stored);
+    }
+  }, []);
+
+  const login = (username, password) => {
+    const logged = loginUser(username, password);
+    if (logged) {
+      setUser(logged);
+      return true;
+    }
+    return false;
+  };
+
+  const register = (username, password) => {
+    const registered = registerUser(username, password);
+    if (registered) {
+      setUser({ username });
+    }
+    return registered;
+  };
+
+  const logout = () => {
+    logoutUser();
+    setUser(null);
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, login, register, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export default AuthContext;

--- a/instagrao/src/paginas/Login.js
+++ b/instagrao/src/paginas/Login.js
@@ -1,18 +1,29 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
+import { useNavigate } from 'react-router-dom';
+import AuthContext from '../context/AuthContext';
 
 const LoginForm = () => {
   const [nomeUsuario, setNomeUsuario] = useState('');
   const [senha, setSenha] = useState('');
   const [errorMessage, setErrorMessage] = useState('');
+  const navigate = useNavigate();
+  const { login, register } = useContext(AuthContext);
 
   const manipulaLogin = () => {
-    // Verificar se o nome de usuário e a senha são válidos (simplificado para este exemplo)
-    if (nomeUsuario === 'usuario' && senha === 'senha123') {
-      // Redirecionar para a página inicial após o login bem-sucedido
-      // Você pode usar react-router-dom para navegação em uma aplicação React
-      window.location.href = '/pagina-inicial';
+    const sucesso = login(nomeUsuario, senha);
+    if (sucesso) {
+      navigate('/pagina-inicial');
     } else {
       setErrorMessage('Nome de usuário ou senha incorretos.');
+    }
+  };
+
+  const manipulaRegistro = () => {
+    const registrado = register(nomeUsuario, senha);
+    if (registrado) {
+      navigate('/pagina-inicial');
+    } else {
+      setErrorMessage('Usuário já existente.');
     }
   };
 
@@ -34,6 +45,7 @@ const LoginForm = () => {
         required
       />
       <button onClick={manipulaLogin}>Entrar</button>
+      <button onClick={manipulaRegistro}>Registrar</button>
       <p style={{ color: 'red' }}>{errorMessage}</p>
     </div>
   );

--- a/instagrao/src/paginas/PaginaInicial.js
+++ b/instagrao/src/paginas/PaginaInicial.js
@@ -1,9 +1,14 @@
-import React from 'react';
+import React, { useContext } from 'react';
+import AuthContext from '../context/AuthContext';
 
 const PaginaInicial = () => {
+  const { user, logout } = useContext(AuthContext);
+
   return (
     <div>
       <h1>Bem-vindo à Página Inicial do Instagrão!</h1>
+      {user && <p>Usuário logado: {user.username}</p>}
+      <button onClick={logout}>Sair</button>
       {/* Conteúdo da sua página inicial */}
     </div>
   );

--- a/instagrao/src/services/authService.js
+++ b/instagrao/src/services/authService.js
@@ -1,0 +1,39 @@
+const USERS_KEY = 'instagrao_users';
+const CURRENT_USER_KEY = 'instagrao_current_user';
+
+function getStoredUsers() {
+  const data = localStorage.getItem(USERS_KEY);
+  return data ? JSON.parse(data) : [];
+}
+
+export function registerUser(username, password) {
+  const users = getStoredUsers();
+  if (users.find((u) => u.username === username)) {
+    return false;
+  }
+  users.push({ username, password });
+  localStorage.setItem(USERS_KEY, JSON.stringify(users));
+  localStorage.setItem(CURRENT_USER_KEY, JSON.stringify({ username }));
+  return true;
+}
+
+export function loginUser(username, password) {
+  const users = getStoredUsers();
+  const user = users.find(
+    (u) => u.username === username && u.password === password
+  );
+  if (user) {
+    localStorage.setItem(CURRENT_USER_KEY, JSON.stringify({ username }));
+    return { username };
+  }
+  return null;
+}
+
+export function getCurrentUser() {
+  const data = localStorage.getItem(CURRENT_USER_KEY);
+  return data ? JSON.parse(data) : null;
+}
+
+export function logoutUser() {
+  localStorage.removeItem(CURRENT_USER_KEY);
+}


### PR DESCRIPTION
## Summary
- add `authService` storing registered users in localStorage
- add `AuthContext` provider for login state
- connect pages to auth context
- replace window.location.href with `useNavigate`
- update failing test

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_683f89c24a408331ba6ef0ab266a9813